### PR TITLE
Fix a bunch of minor typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Advice for learning Rust
 I'm mainly active in the Rust community via [URLO.](https://users.rust-lang.org/)
 The first version of this guide has its roots in a post on the forum where someone
 asked for general advice for understanding and fixing borrow-check errors.  They
-subseqently [asked if it could be made easier to find,](https://users.rust-lang.org/t/practical-suggestions-for-fixing-lifetime-errors/92634/17)
-and I created this guide respository as a result.
+subsequently [asked if it could be made easier to find,](https://users.rust-lang.org/t/practical-suggestions-for-fixing-lifetime-errors/92634/17)
+and I created this guide repository as a result.
 
 Corrections and suggested additions are welcome, but be fore-warned that I
 can be very slow and sporadic to respond on GitHub.

--- a/src/community.md
+++ b/src/community.md
@@ -14,7 +14,7 @@ to solve their problems -- or even just experiment with them! -- yourself.
 By being an active participant, you can not only learn more, but will eventually
 be able to help out other users.
 * When you read a question and are lost: read the replies and see if you can understand them and learn more
-* When you have played with a question and got it to comple but aren't sure why: reply with something like
+* When you have played with a question and got it to compile but aren't sure why: reply with something like
   "I don't know if this fixes your use case, but this compiles for me: [Playground](https://play.rust-lang.org/)"
 * After you've got the hang of certain common problems: "It's because of XYZ.  You can do this instead: ..."
 

--- a/src/community.md
+++ b/src/community.md
@@ -1,6 +1,6 @@
 # Keep at it and participate in the community
 
-Experience plays a very big role in undestanding borrow errors and being able
+Experience plays a very big role in understanding borrow errors and being able
 to figure out why some code is problematic in a reasonable amount of time.
 Running into borrow check errors and solving them, either on your own or by
 asking for help, is a part of the process of building up that intuition.

--- a/src/dyn-elision-advanced.md
+++ b/src/dyn-elision-advanced.md
@@ -78,7 +78,7 @@ fn example<'a, 'b>() {
 In this particular example, the lifetime will be inferred
 [analogously to the lifetime intersection mentioned previously.](dyn-trait-lifetime.md#when-multiple-lifetimes-are-involved))
 
-## Iteraction with type aliases
+## Interaction with type aliases
 
 When you use a type alias, the bounds between lifetime parameters and type
 parameters *on the `type` alias* determine how `dyn Trait` lifetime elision

--- a/src/dyn-elision-basic.md
+++ b/src/dyn-elision-basic.md
@@ -2,7 +2,7 @@
 
 As a reminder, `dyn Trait` is a type constructor which is parameterized with a
 lifetime; a fully resolved type includes the lifetime, such as `dyn Trait + 'static`.
-The lifetime can be elided in many sitations, in which case the actual lifetime
+The lifetime can be elided in many situations, in which case the actual lifetime
 used may take on some default lifetime, or may be inferred.
 
 When talking about default trait object (`dyn Trait`) lifetimes, we're talking about

--- a/src/dyn-elision-citations.md
+++ b/src/dyn-elision-citations.md
@@ -26,12 +26,12 @@ In particular, as of this writing, the official documentation states that
 
 Some differences from the reference which we have covered are that
 - [inferring bounds in expressions applies to `&T` types unless annotated with a named lifetime](./dyn-elision-advanced.md#an-exception-to-inference-in-function-bodies)
-- [inferring bounds in expressions applies to ambigous types](./dyn-elision-advanced.md#ambiguous-bounds)
+- [inferring bounds in expressions applies to ambiguous types](./dyn-elision-advanced.md#ambiguous-bounds)
 - [when trait bounds apply, they override struct bounds, not the other way around](./dyn-elision-trait-bounds.md#when-they-apply-trait-lifetime-bounds-override-struct-bounds)
 - [a `'static` trait bound always applies](./dyn-elision-trait-bounds.md#the-static-case)
 - [otherwise, whether trait bounds apply or not depends on complicated contextual rules](./dyn-elision-trait-bounds.md#when-and-how-to-trait-lifetime-bounds-apply)
   - they always apply in `impl` headers, associated types, and function bodies
-  - and technically in `static` contexts, with some odd cavaets
+  - and technically in `static` contexts, with some odd caveats
   - whether they apply in function signatures depends on the bounding parameters being late or early bound
     - a single parameter can apply to a trait bounds with multiple bounds in this context, introducing new implied lifetime bounds
 - [trait bounds override `'_` in function bodies](./dyn-elision-trait-bounds.md#function-bodies)
@@ -52,7 +52,7 @@ Trait objects used to be just "spelled" as `Trait` in type position, instead of 
 - [RFC 0192](https://rust-lang.github.io/rfcs/0192-bounds-on-object-and-generic-types.html#lifetime-bounds-on-object-types) first introduced the trait object lifetime
   - [including the "intersection lifetime" consideration](https://rust-lang.github.io/rfcs/0192-bounds-on-object-and-generic-types.html#appendix-b-why-object-types-must-have-exactly-one-bound)
 - [RFC 0599](https://rust-lang.github.io/rfcs/0599-default-object-bound.html) first introduced *default* trait object lifetimes (`dyn Trait` lifetime elision)
-- [RFC 1156](https://rust-lang.github.io/rfcs/1156-adjust-default-object-bounds.html) superceded RFC 0599 (`dyn Trait` lifetime elision)
+- [RFC 1156](https://rust-lang.github.io/rfcs/1156-adjust-default-object-bounds.html) superseded RFC 0599 (`dyn Trait` lifetime elision)
 - [PR 39305](https://github.com/rust-lang/rust/pull/39305) modified RFC 1156 (unofficially) to [allow more inference in function bodies](dyn-elision-advanced.md#an-exception-to-inference-in-function-bodies)
 - [RFC 2093](https://rust-lang.github.io/rfcs/2093-infer-outlives.html#trait-object-lifetime-defaults) defined [how `struct` bounds interact with `dyn Trait` lifetime elision](dyn-elision-advanced.md#guiding-behavior-of-your-own-types)
 - [Issue 100270](https://github.com/rust-lang/rust/issues/100270) notes that type aliases take precedent in terms of RFC 2093 `dyn Trait` lifetime elision rules

--- a/src/dyn-elision-trait-bounds.md
+++ b/src/dyn-elision-trait-bounds.md
@@ -375,7 +375,7 @@ late-bound lifetimes.
 
 As mentioned above, trait object bounds always apply in function bodies,
 similar to function signatures where every lifetime is early-bound.  This
-is true irregardless of whether the lifetimes are early or late bound in
+is true regardless of whether the lifetimes are early or late bound in
 the function signature.
 ```rust
 trait Single<'a>: 'a {}

--- a/src/dyn-hr.md
+++ b/src/dyn-hr.md
@@ -223,7 +223,7 @@ let _: Box<dyn Fn(&_: &i32)> = Box::new(|_| {});
 ```
 
 Why the differences? One reason is that
-[patterns are gramatically incompatible with anonymous arguments,
+[patterns are grammatically incompatible with anonymous arguments,
 apparently.](https://github.com/rust-lang/rust/issues/41686#issuecomment-366611096)
 I'm uncertain as to why identifiers are accepted on function pointers,
 however, or more generally why the `Fn` sugar is inconsistent with

--- a/src/dyn-safety.md
+++ b/src/dyn-safety.md
@@ -157,7 +157,7 @@ now it's a restricted set.
 In order to support type-generic methods, there would need to be
 a function pointer in the vtable for every possible type that the
 generic could take on.  Not only would this create vtables of
-unweildly size, it would also require some sort of global analysis.
+unwieldly size, it would also require some sort of global analysis.
 After all, every crate which uses your trait might define new types
 that meet the trait bounds in question, and they (or you) might also
 want to call the method using those types.

--- a/src/dyn-trait-borrow.md
+++ b/src/dyn-trait-borrow.md
@@ -198,7 +198,7 @@ or even just rearranging the field order.
 Instead, we implement the traits directly by deferring to the borrowed type:
 ```rust
 # struct Data; impl Data { fn lend(&self) {} }
-// Excercise for the reader: `PartialEq` across all of our
+// Exercise for the reader: `PartialEq` across all of our
 // owned and borrowed types :-)
 impl std::cmp::PartialEq for Data {
     fn eq(&self, other: &Self) -> bool {

--- a/src/dyn-trait-box-impl.md
+++ b/src/dyn-trait-box-impl.md
@@ -60,7 +60,7 @@ the `Box` because it's unsized.  And we can't
 [downcast from `dyn Trait`](./dyn-any.md#downcasting-methods-are-not-trait-methods)
 either; even if we could, it would rarely help here, as we'd have to both
 impose a `'static` constraint and also know every type that implements our
-trait to attempt downcasting on each one (or have some other clever scehme
+trait to attempt downcasting on each one (or have some other clever scheme
 for more efficient downcasting).
 
 Ugh, no wonder `Box<dyn Trait>` doesn't implement `Trait` automatically.
@@ -97,7 +97,7 @@ impl Trait for Box<dyn Trait + '_> {
 ```
 
 By adding the supertrait bound, the compiler will supply an implementation of
-`BoxedBye for dyn Trait + '_`.  That implementation will call the implemenation
+`BoxedBye for dyn Trait + '_`.  That implementation will call the implementation
 of `BoxedBye` for `Box<Erased>`, where `Erased` is the erased base type.  That
 is our blanket implementation, which unboxes `Erased` and calls `Erased`'s
 `Trait::bye`.

--- a/src/dyn-trait-coercions.md
+++ b/src/dyn-trait-coercions.md
@@ -40,7 +40,7 @@ So what should the associated types be in the implementation of `Trait` for
 There is no single answer; they would need to vary based on the erased base types.
 
 However, `dyn Trait` for traits with associated types is just too useful to
-make traits with associated types inelligible for `dyn Trait`.  Instead, associated
+make traits with associated types ineligible for `dyn Trait`.  Instead, associated
 types in the trait become, in essence, named *type parameters* of the `dyn Trait`
 type constructor. (Recall it's already a type constructor due to the trait object lifetime.)
 
@@ -84,7 +84,7 @@ trait AssocAndParams<T, U> { type Assoc1; type Assoc2; }
 
 // The trait's ordered type parameters must be in declaration order
 // (here, `String` then `usize`).  After that come the named associated
-// type paramters, which can be reordered arbitrary amongst themselves.
+// type parameters, which can be reordered arbitrary amongst themselves.
 fn foo(d: Box<dyn AssocAndParams<String, usize, Assoc1 = i32, Assoc2 = u32>>)
 ->
     Box<dyn AssocAndParams<String, usize, Assoc2 = u32, Assoc1 = i32>>
@@ -171,7 +171,7 @@ erased `str`, you've lost the information that `&str` is also a wide pointer,
 and how to create that wide pointer.  However, the code would need to recreate
 a wide pointer in order to perform dynamic dispatch.
 
-So for `dyn Trait` to non-naively support unsized types, it would need need
+So for `dyn Trait` to non-naively support unsized types, it would need
 to examine at run-time how to construct a pointer to the erased base type:
 one possibility for thin pointers, and an additional possibility for each type
 of wide pointer supported.  Not only that, but the metadata required (such as

--- a/src/dyn-trait-eq.md
+++ b/src/dyn-trait-eq.md
@@ -30,7 +30,7 @@ However, now we have two wide pointers which may point to different
 base types.  In this particular application, we only really need to
 know if they have the same base type or not... though it would be
 nice to have some *safe* way to recover the erased type of non-receiver
-too, instead of whatever casting schenanigans might be necessary.
+too, instead of whatever casting shenanigans might be necessary.
 
 You might think you could somehow use the vtable pointers to see if
 the base types are the same.  But unfortunately, [we can't rely on the
@@ -39,7 +39,7 @@ vtable to compare their types at runtime.](https://doc.rust-lang.org/std/ptr/fn.
 > When comparing wide pointers, both the address and the metadata are
 tested for equality. However, note that comparing trait object pointers
 (`*const dyn Trait`) is unreliable: pointers to values of the same
-underlying type can compare inequal (because vtables are duplicated in
+underlying type can compare unequal (because vtables are duplicated in
 multiple codegen units), and pointers to values of different underlying
 type can compare equal (since identical vtables can be deduplicated
 within a codegen unit).

--- a/src/dyn-trait-erased.md
+++ b/src/dyn-trait-erased.md
@@ -178,7 +178,7 @@ so now we're good to go!
 You may have noticed how we took care to avoid boxing the iterator when possible
 by being mindful of how we implemented some of the methods, for example not
 having a default body for `erased::Iterable::visit`, and then overriding the
-the default body of `useful::Iterable::visit`.  This can lead to better performance
+default body of `useful::Iterable::visit`.  This can lead to better performance
 but isn't necessarily critical, so long as you avoid things like accidental
 infinite recursion.
 

--- a/src/dyn-trait-impls.md
+++ b/src/dyn-trait-impls.md
@@ -110,7 +110,7 @@ impl Trait for dyn Trait + '_ {
 }
 ```
 
-In short, the compiler knows how to go from the type-earased form
+In short, the compiler knows how to go from the type-erased form
 (like `Box<Self>`) into something ABI compatible for the base type
 (`Box<BaseType>`) for every supported receiver type.
 
@@ -135,7 +135,7 @@ an implementation of `Trait`.
 
 ## `Box<dyn Trait>` and `&dyn Trait` do not automatically implement `Trait`
 
-It may come as a suprise that neither `Box<dyn Trait>` nor
+It may come as a surprise that neither `Box<dyn Trait>` nor
 `&dyn Trait` automatically implement `Trait`.  Why not?
 
 In short, because it's not always possible.
@@ -227,7 +227,7 @@ dt.hi();
 and applies to the supertrait implementations for `dyn Trait` as well.
 
 [We'll see that this can be useful later.](./dyn-trait-erased.md)  But
-unfortunately, [there are some compilier bugs around the compiler
+unfortunately, [there are some compiler bugs around the compiler
 implementation taking precedence over your blanket implementations.](https://github.com/rust-lang/rust/issues/57893#issuecomment-510690333)
 How those bugs are dealt with is yet to be determined; it's possible
 that certain blanket implementations will be disallowed, or that

--- a/src/dyn-trait-overview.md
+++ b/src/dyn-trait-overview.md
@@ -141,7 +141,7 @@ We'll explore more details on the interaction of generics and `dyn Trait`
 You may wonder why you can use the methods of `Trait` on a `&dyn Trait` or
 `Box<dyn Trait>`, etc., despite not declaring any such bound.  The reason is
 analogous to why you can use `Display` methods on a `String` without declaring
-that bound, say: the type is staically known, and the compiler recognizes that
+that bound, say: the type is statically known, and the compiler recognizes that
 `dyn Trait` implements `Trait`, just like it recognizes that `String`
 implements `Display`.  Trait bounds are needed for generics, not concrete types.
 

--- a/src/dyn-trait-vs.md
+++ b/src/dyn-trait-vs.md
@@ -40,7 +40,7 @@ There may be more differences in the future, but for now at least,
 generics are the more flexible and thus superior form -- unless you
 have a burning hatred against the `<...>` syntax, anyway.
 
-At any rate, comparing `dyn Trait` against APIT is essencially the
+At any rate, comparing `dyn Trait` against APIT is essentially the
 same as comparing `dyn Trait` against a function with a generic type
 parameter.
 
@@ -227,7 +227,7 @@ where
 ```
 The pattern is to have a function which is parameterized by a generic type
 return a concrete (nominal) struct, also parameterized by the generic type.
-This is possible even if the paramter itself is unnameable -- for example,
+This is possible even if the parameter itself is unnameable -- for example,
 in the case of `map`, the `F: FnMut(Self::Item) -> B` parameter might well
 be an unnameable closure.
 
@@ -241,7 +241,7 @@ such.
 The upside is that you (and the consumers of your method) get many of the upsides of both RPIT and `dyn Trait`:
 - No dynamic dispatch penalty
 - No boxing penalty
-- No concrete-type specific optimzation loss
+- No concrete-type specific optimization loss
 - No single trait limitation
 - No `dyn`-safe limitation
 - Applicable in traits
@@ -278,7 +278,7 @@ erasure is a question of functionality, and not really much of a choice.
 However, you may also want to use type erasure in your data types in order
 to make your own struct non-generic.  When your data type is generic, after
 all, those who use your data type in such a way that the parameter takes on
-more than one type will have to propogate the use of generics themselves, or
+more than one type will have to propagate the use of generics themselves, or
 face the decision of type erasing your data type themselves.
 
 This can not only be a question of ergonomics, but also of compile time and
@@ -296,7 +296,7 @@ For example, the failure to devirtualize and inline a call to
 `<dyn Iterator>::next` in a tight loop may have a relatively large impact,
 whereas a dynamic callback that only fires occasionally (and then dispatches
 to the optimized, non-type-erased implementation) is not likely to be
-noticable at all.
+noticeable at all.
 
 ## `enum`s
 

--- a/src/elision.md
+++ b/src/elision.md
@@ -10,9 +10,9 @@ If you get a lifetime error involving elided lifetimes, try giving all the lifet
 the compiler errors; if nothing else, you won't have to work so hard to mentally track the numbers used in
 errors for illustration, or what "anonymous lifetime" is being talked about.
 
-Take care to refer to the elision rules when naming all the lifetimes, or you may inadverently change the
+Take care to refer to the elision rules when naming all the lifetimes, or you may inadvertently change the
 meaning of the signature.  If the error changes *drastically,* you've probably changed the meaning of the
-siguature.
+signature.
 
 Once you have a good feel for the function lifetime elision rules, you'll start developing intuition for
 when you need to name your lifetimes instead.

--- a/src/lifetime-analysis.md
+++ b/src/lifetime-analysis.md
@@ -184,7 +184,7 @@ Usually in this case, one uses methods like [`split_at_mut`](https://doc.rust-la
 in order to split the borrows instead.
 
 Similarly to indexing, when you access something through "deref coercion", you're
-excercising [the `Deref` trait](https://doc.rust-lang.org/std/ops/trait.Deref.html)
+exercising [the `Deref` trait](https://doc.rust-lang.org/std/ops/trait.Deref.html)
 (or `DerefMut`), which borrow all of `self`.
 
 There are also some niche cases where the borrow checker is smarter, however.

--- a/src/m-naming.md
+++ b/src/m-naming.md
@@ -25,5 +25,5 @@ fn quz(&mut self) -> &str { todo!() }
 ```
 
 As covariance and function lifetime elision become more intuitive, you'll build a feel for when it's
-pointless to name lifetimes.  Adding surpuflous lifetimes like in the first example tends to make
+pointless to name lifetimes.  Adding superfluous lifetimes like in the first example tends to make
 understanding borrow errors harder, not easier.

--- a/src/pf-meta.md
+++ b/src/pf-meta.md
@@ -24,7 +24,7 @@ impl<'a> Snek<'a> {
 }
 ```
 
-[And as was covered before,](pf-borrow-forever.md) that's an anti-pattern because you cannot use the self-referencial struct directly ever again.
+[And as was covered before,](pf-borrow-forever.md) that's an anti-pattern because you cannot use the self-referential struct directly ever again.
 The only way to use it at all is via a (reborrowed) return value from the method call that required `&'a mut self`.
 
 So it's technically possible, but so restrictive it's pretty much always useless.

--- a/src/st-bounds.md
+++ b/src/st-bounds.md
@@ -41,5 +41,5 @@ the value's "lifetime".  Although there is a connection between the liveness sco
 and lifetimes of references you take to it, conflating the two concepts can lead to confusion.
 
 That said, not everyone follows this convention, so you may see the liveness scope of a value
-refered to as the values "lifetime".  So the distinction is something to just generally be
+referred to as the values "lifetime".  So the distinction is something to just generally be
 aware of.

--- a/src/st-model.md
+++ b/src/st-model.md
@@ -4,7 +4,7 @@ Some find it helpful to think of shared (`&T`) and exclusive (`&mut T`) referenc
 
 * `&T` is a compiler-checked `RwLockReadGuard`
   * You can have as many of these at one time as you want
-* `&mut T` is an compiler-checked `RwLockWriteGuard`
+* `&mut T` is a compiler-checked `RwLockWriteGuard`
   * You can only have one of these at one time, and when you do, you can have no `RwLockReadGuard`
 
 The exclusivity is key.

--- a/src/st-more-invariance.md
+++ b/src/st-more-invariance.md
@@ -7,6 +7,6 @@ it's present elsewhere as well.
 
 Trait parameters are invariant too.  As a result, lifetime-parameterized traits can be onerous to work with.
 
-Additionally, if you have a bound like `T: Trait<U>`, `U` becomes invariant becase it's a type parameter of the trait.
+Additionally, if you have a bound like `T: Trait<U>`, `U` becomes invariant because it's a type parameter of the trait.
 If your `U` resolves to `&'x V`, the lifetime `'x` will be invariant too.
 

--- a/src/st-types.md
+++ b/src/st-types.md
@@ -2,7 +2,7 @@
 
 Let's open with a question: is `&str` a type?
 
-When not being pendantic or formal, pretty much everyone will say yes, `&str` is a type.
+When not being pedantic or formal, pretty much everyone will say yes, `&str` is a type.
 However, it is technically a *type constructor* which is parameterized with a generic
 lifetime parameter.  So `&str` isn't technically a type, `&'a str` for some concrete
 lifetime is a type.
@@ -10,7 +10,7 @@ lifetime is a type.
 Similarly, `Vec<T>` for a generic `T` is a type constructor, but `Vec<i32>` is a type.
 
 By "concrete lifetime", I mean some compile-time determined lifetime.  The exact
-definition of "lifetime" is suprisingly complicated and beyond the scope of this
+definition of "lifetime" is surprisingly complicated and beyond the scope of this
 guide, but here are a few examples of `&str`s and their concrete types.
 
 ```rust


### PR DESCRIPTION
Found one naturally by reading the book, then ran a spellchecker across the rest of the markdown to find the rest. Lots of false positives though due to all the Rust jargon, so all the corrections here are manually verified by me.